### PR TITLE
Allow a user to change mount status and specify custom options.

### DIFF
--- a/manifests/s3_mount.pp
+++ b/manifests/s3_mount.pp
@@ -5,29 +5,36 @@
 #
 # === Parameters
 #
-# [*s3_bucket_name*]
-#   The name of the s3 bucket. By default, it uses the title.
+# [*ensure*]
+#   Control what to do with this mount. Acceps the same values as the 'mount' type.
 #
 # [*mount_point*]
 #   The path to mount.  Note, this module ensures the directory exists.
 #
+# [*options*]
+#   Options used when mounting.
+#
+# [*s3_bucket_name*]
+#   The name of the s3 bucket. By default, it uses the title.
+#
 define amazon_s3::s3_mount(
+  $ensure = 'mounted',
   $mount_point,
+  $options = 'allow_other',
   $s3_bucket_name = $title,
 ){
-  
   file{$mount_point:
     ensure => directory,
     mode   => '0777',
   }
-  
+
   # mount the s3 bucket
   mount { $title:
-    ensure  => 'mounted',
+    ensure  => $ensure,
     name    => $mount_point,
     device  => "s3fs#${s3_bucket_name}",
     fstype  => 'fuse',
-    options => 'allow_other',
+    options => $options,
     require => File[$mount_point],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,8 @@
   ],
   "dependencies": [
     {
-    	"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0"
+    	"name":"puppetlabs-stdlib",
+      "version_requirement":">= 4.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",


### PR DESCRIPTION
I guess s3_mount should either mimic parameters of the mount type or be deprecated in favor of the mount type (with proper update to the docs).

What do you think?
